### PR TITLE
💄 Fix button animation while fetching repos

### DIFF
--- a/app/scripts/reducers/github.js
+++ b/app/scripts/reducers/github.js
@@ -25,7 +25,7 @@ export default {
           },
           message: { $set: '' },
           query: { $set: payload.query },
-          status: { $set: STATUS.IDLE },
+          status: { $set: STATUS.RUNNING },
         },
       });
     },

--- a/test/reducers/__snapshots__/github.spec.js.snap
+++ b/test/reducers/__snapshots__/github.spec.js.snap
@@ -8,7 +8,7 @@ Object {
     },
     "message": "",
     "query": undefined,
-    "status": "idle",
+    "status": "running",
   },
 }
 `;


### PR DESCRIPTION
GitHub component expects `github.repos.status` to equal `running` in order to display a loading animation inside buttons

![screen shot 2018-09-12 at 17 46 08](https://user-images.githubusercontent.com/6432271/45452240-d8f2eb80-b6b3-11e8-899c-f37920d7b074.png)
