### PR TITLE
Updated the cypress config due to deprecated features. 

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,5 @@
 {
   "viewportHeight": 800,
   "viewportWidth": 1280,
-  "videoRecording": false,
-  "screenshotOnHeadlessFailure" : false
+  "video": false
 }

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -18,3 +18,7 @@ import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+Cypress.Screenshot.defaults({
+    screenshotOnRunFailure: false
+})


### PR DESCRIPTION
- `screenshotOnRunFailure` is no longer supported in the `cypress.json` config; it is now migrated to the `cypress/support/index.js` as a function. 

- `videoRecording` has been renamed to just video