### PR TITLE
Fix dotenv-expand usage

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -29,7 +29,7 @@ const dotenvFiles = [
 // https://github.com/motdotla/dotenv-expand
 dotenvFiles.forEach(dotenvFile => {
   if (fs.existsSync(dotenvFile)) {
-    require('dotenv-expand')(
+    require('dotenv-expand').expand(
       require('dotenv').config({
         path: dotenvFile,
       }),


### PR DESCRIPTION
## Desciption
- When using env file, I get `TypeError: require(...) is not a function` error.
- The cause is https://github.com/gilbarbara/react-redux-saga-boilerplate/blob/master/config/env.js#L32

## Solution
I use `expand` function supported by [dotenv-expand](https://github.com/motdotla/dotenv-expand)